### PR TITLE
fix: npm publish on win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,9 @@
   "bin": {
     "gen-api-models": "dist/index.js"
   },
-  "files": [
-    "dist/",
-    "templates/"
-  ],
+  "files": ["dist/", "templates/"],
   "scripts": {
+    "prepublishOnly": "crlf --set=LF dist/*",
     "prepublish": "npm run build",
     "build": "rimraf dist && tsc",
     "version": "npm run build",
@@ -34,6 +32,7 @@
     "@types/prettier": "^1.12.0",
     "@types/swagger-parser": "^4.0.2",
     "@types/yargs": "^11.0.0",
+    "crlf": "^1.1.1",
     "danger": "^3.5.1",
     "danger-plugin-digitalcitizenship": "^0.3.1",
     "io-ts": "^1.1.4",
@@ -51,15 +50,10 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ],
+    "moduleFileExtensions": ["ts", "js"],
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testMatch": [
-      "**/__tests__/*.ts"
-    ]
+    "testMatch": ["**/__tests__/*.ts"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-utils",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Tools and utilities for the Digital Citizenship project",
   "repository": "https://github.com/teamdigitale/italia-utils",
   "author": "https://teamdigitale.governo.it",
@@ -8,7 +8,10 @@
   "bin": {
     "gen-api-models": "dist/index.js"
   },
-  "files": ["dist/", "templates/"],
+  "files": [
+    "dist/",
+    "templates/"
+  ],
   "scripts": {
     "prepublishOnly": "crlf --set=LF dist/*",
     "prepublish": "npm run build",
@@ -50,10 +53,15 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "moduleFileExtensions": ["ts", "js"],
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testMatch": ["**/__tests__/*.ts"]
+    "testMatch": [
+      "**/__tests__/*.ts"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,13 @@ cpx@^1.5.0:
     shell-quote "^1.6.1"
     subarg "^1.0.0"
 
+crlf@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/crlf/-/crlf-1.1.1.tgz#24172841b4c83529a6aa4489df7eed958b2ed16f"
+  dependencies:
+    glub "^1.0.0"
+    transform-file "^1.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1590,6 +1597,16 @@ glob2base@^0.0.12:
   dependencies:
     find-index "^0.1.1"
 
+glob@^5.0.5:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -1608,6 +1625,13 @@ globals@^8.3.0:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+glub@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/glub/-/glub-1.0.3.tgz#56c1643298ae25065c6315003337bba69d2fb866"
+  dependencies:
+    glob "^5.0.5"
+    minimist "^1.1.1"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -2842,7 +2866,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4066,6 +4090,12 @@ tr46@^1.0.1:
 tr46@~0.0.1:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+transform-file@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/transform-file/-/transform-file-1.0.1.tgz#7f95984acd23d4ebf8abb47ee9d83be166d12687"
+  dependencies:
+    os-tmpdir "^1.0.0"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
npm publish on win32 produces corrupted binaries because of line endings.